### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ const compatiblePlusOne = fromUnary(plusOne)
 Now we can use these functions in our pipeline.
 
 #### Composing functions into a pipeline
-Now that we have compatible functions, let's compose them into a single function using the `pipeline` function.
+Now that we have compatible functions, let's compose them into a single function using the `compose` function.
 
 ```javascript
-import { fromUnary, pipeline, SomeError, Success } from 'baccano'
+import { fromUnary, compose, SomeError, Success } from 'baccano'
 
 const pipeline = compose(compatiblePlusOne, compatibleDivideByZero, compatiblePlusOne)
 ```


### PR DESCRIPTION
## What this PR does

Replace non-existing "pipeline" export with correct "compose" export in the documentation example

## Why

I think you meant "compose" there, also there's no "pipeline" export in the library (:

